### PR TITLE
Bring back 2 archs during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,9 +285,8 @@ jobs:
           file: ./${{ env.DOCKERFILE }}
           platforms: |
             linux/amd64
-          # bypass arch during CI test
-          #linux/arm64
-          #linux/arm/v7
+            linux/arm64
+            linux/arm/v7
           push: true
           tags: |
             ${{ needs.myvars.outputs.DKR_PREFIX }}:${{ needs.myvars.outputs.BRANCH_NAME }}


### PR DESCRIPTION
I disabled these 2 archs while working on the CI. 
Let's enable it them.