### PR TITLE
Update to Ghost 4.44.0 + Fix sqlite node module deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # These ARG are required during the Github Actions CI
 # ----------------------------------------------
 ARG APP_NAME="ghostfire"
-ARG VERSION="4.41.3"
-ARG RELEASE="4.41.3"
+ARG VERSION="4.44.0"
+ARG RELEASE="4.44.0"
 ARG GITHUB_USER="firepress-org"
 
 ARG GIT_PROJECT_NAME="ghostfire"


### PR DESCRIPTION
Apologies for the delay, been crazy busy the last few weeks. I figured out what the issue was, I think. From the looks of it, the --ignore-optional flag during the sqlite install was uninstalling other node module dependencies that were marked as optional 🤔

https://github.com/docker-library/ghost/pull/297#issuecomment-1101921390
Signed-off-by: Pascal Andy <pascalandy@users.noreply.github.com>