### PR TITLE
Add an healthcheck

### DIFF
--- a/v5/Dockerfile
+++ b/v5/Dockerfile
@@ -172,5 +172,8 @@ VOLUME "${GHOST_CONTENT}"
 USER "${USER}"
 EXPOSE 2368
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+	CMD wget --quiet --tries=1 --spider http://localhost:2368 || exit 1
+
 ENTRYPOINT [ "docker-entrypoint.sh" ]
 CMD [ "node", "current/index.js" ]


### PR DESCRIPTION
This PR adds a healthcheck to our Dockerfile for the Ghost application. The healthcheck will help ensure that the container is running properly and that the Ghost service is accessible.
