### PR TITLE
allows Dependabot to auto-merge its PRs

### DIFF
--- a/.github/workflows/ghostv4.yml
+++ b/.github/workflows/ghostv4.yml
@@ -9,8 +9,6 @@
 name: Ghost V4 alpine
 
 on:
-  schedule:
-    - cron: "0 0 1 * *" # once a month
   pull_request:
     branches: [lts_v4]
   push:

--- a/.github/workflows/ghostv5.yml
+++ b/.github/workflows/ghostv5.yml
@@ -26,6 +26,11 @@ env:
   # needed to define path within 'uses'
   SUB_DIR: "v5"
 
+permissions:
+  contents: read
+  packages: write # if you're pushing to GitHub Packages
+  pull-requests: write # allows Dependabot to auto-merge its PRs if you've configured it to do so
+
 defaults:
   run:
     shell: "bash -Eeuo pipefail -x {0}"


### PR DESCRIPTION
- **remove schedule to build Ghost v4**
- **allows Dependabot to auto-merge its PRs if you've configured it to do so**
