### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ghostv5.yml
+++ b/.github/workflows/ghostv5.yml
@@ -345,7 +345,7 @@ jobs:
           timezone: America/Montreal
 
       - name: cd stable
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.NODE1 }}
           port: ${{ secrets.SSH_PORT }}


### PR DESCRIPTION
This PR updates several GitHub Actions dependencies to their latest versions:

## Updates Included

### 1. crazy-max/ghaction-github-status: 4.1.0 → 4.2.0
- **Commit**: 14175da
- **Location**: Line 55 in 
- **Purpose**: GitHub Actions system status monitoring

### 2. aquasecurity/trivy-action: 0.29.0 → 0.30.0
- **Commit**: 1e5baaa
- **Location**: Line 447 in 
- **Purpose**: Container vulnerability scanning

### 3. docker/login-action: 3.2.0 → 3.4.0
- **Commit**: 4cd4386
- **Locations**: Multiple occurrences (lines 174, 178, 259, 263, 518, 523, 685)
- **Purpose**: Docker registry authentication for both DockerHub and GitHub Container Registry

### 4. appleboy/ssh-action: 1.2.0 → 1.2.2
- **Commit**: f8c7a65
- **Location**: Line 348 in 
- **Purpose**: SSH deployment for continuous deployment

## Benefits
- Security improvements and bug fixes from upstream updates
- Better compatibility with current GitHub Actions infrastructure
- Maintains workflow reliability and performance

## Testing
All updates maintain backward compatibility with existing workflow configuration. No breaking changes are expected.

## Related Issues
This addresses the following Dependabot PRs:
- #579: Bump crazy-max/ghaction-github-status from 4.0.0 to 4.2.0
- #578: Bump aquasecurity/trivy-action from 0.23.0 to 0.30.0
- #577: Bump docker/login-action from 3.2.0 to 3.4.0
- #576: Bump appleboy/ssh-action from 1.0.3 to 1.2.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying workflow actions to newer versions for improved stability and maintenance. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->