### PR TITLE
Update: registry cache and update to Ghost version 5.112.0

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 
 APP_NAME="ghostfire"
 GITHUB_USER="firepress-org"
-APP_VERSION="5.112.0"
+APP_VERSION="5.113.0"
 
 ### function options
 CFG_USE_GPG_SIGNATURE="false"

--- a/.github/workflows/ghostv5.yml
+++ b/.github/workflows/ghostv5.yml
@@ -193,10 +193,13 @@ jobs:
           # linux/arm/v8
           # linux/arm/v7
           push: true
+          # The order for <docker push -tag> matters for our CD down the line
           tags: |
             ${{ needs.myvars.outputs.TAG_DKR_BRANCH_NAME }}
             ${{ needs.myvars.outputs.TAG_GPR_BRANCH_NAME }}
-          # The order for <docker push -tag> matters for our CD down the line
+          # This configuration intentionally uses the SAME cache reference for both jobs.
+          # The goal is for the 'stable' build (triggered by a tag) to reuse the
+          # layers already created by the 'edge' build on the master branch.
           cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}
           cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }},mode=max
           build-args: |
@@ -278,6 +281,7 @@ jobs:
           # linux/arm/v8
           # linux/arm/v7
           push: true
+          # The order for <docker push -tag> matters for our CD down the line
           tags: |
             ${{ needs.myvars.outputs.TAG_DKR_VERSION }}
             ${{ needs.myvars.outputs.TAG_DKR_BRANCH_NAME }}
@@ -287,7 +291,6 @@ jobs:
             ${{ needs.myvars.outputs.TAG_GPR_BRANCH_NAME }}
             ${{ needs.myvars.outputs.TAG_GPR_VERSION_HASH_ONLY }}
             ${{ needs.myvars.outputs.TAG_GPR_VERSION_HASH_DATE }}
-          # The order for <docker push -tag> matters for our CD down the line
           cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}
           cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }},mode=max
           build-args: |

--- a/.github/workflows/ghostv5.yml
+++ b/.github/workflows/ghostv5.yml
@@ -197,8 +197,8 @@ jobs:
             ${{ needs.myvars.outputs.TAG_DKR_BRANCH_NAME }}
             ${{ needs.myvars.outputs.TAG_GPR_BRANCH_NAME }}
           # The order for <docker push -tag> matters for our CD down the line
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}, mode=max
+          cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}
+          cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }},mode=max
           build-args: |
             BUILDKIT_PROGRESS=plain
           network: host
@@ -288,8 +288,8 @@ jobs:
             ${{ needs.myvars.outputs.TAG_GPR_VERSION_HASH_ONLY }}
             ${{ needs.myvars.outputs.TAG_GPR_VERSION_HASH_DATE }}
           # The order for <docker push -tag> matters for our CD down the line
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}, mode=max
+          cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}
+          cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }},mode=max
           build-args: |
             BUILDKIT_PROGRESS=plain
           network: host

--- a/.github/workflows/ghostv5.yml
+++ b/.github/workflows/ghostv5.yml
@@ -200,8 +200,8 @@ jobs:
           # This configuration intentionally uses the SAME cache reference for both jobs.
           # The goal is for the 'stable' build (triggered by a tag) to reuse the
           # layers already created by the 'edge' build on the master branch.
-          cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}
-          cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }},mode=max
+          cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}-${{ github.run_id }}
+          cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}-${{ github.run_id }},mode=max
           build-args: |
             BUILDKIT_PROGRESS=plain
           network: host
@@ -291,8 +291,8 @@ jobs:
             ${{ needs.myvars.outputs.TAG_GPR_BRANCH_NAME }}
             ${{ needs.myvars.outputs.TAG_GPR_VERSION_HASH_ONLY }}
             ${{ needs.myvars.outputs.TAG_GPR_VERSION_HASH_DATE }}
-          cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}
-          cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }},mode=max
+          cache-from: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}-${{ github.run_id }}
+          cache-to: type=registry,ref=${{ needs.myvars.outputs.GPR_PREFIX }}:buildcache-${{ env.SUB_DIR }}-${{ github.run_id }},mode=max
           build-args: |
             BUILDKIT_PROGRESS=plain
           network: host

--- a/.github/workflows/ghostv5.yml
+++ b/.github/workflows/ghostv5.yml
@@ -193,7 +193,7 @@ jobs:
           # linux/arm/v8
           # linux/arm/v7
           push: true
-          # The order for <docker push -tag> matters for our CD down the line
+          # The order for `docker push -tag` matters for our CD down the line
           tags: |
             ${{ needs.myvars.outputs.TAG_DKR_BRANCH_NAME }}
             ${{ needs.myvars.outputs.TAG_GPR_BRANCH_NAME }}
@@ -281,7 +281,7 @@ jobs:
           # linux/arm/v8
           # linux/arm/v7
           push: true
-          # The order for <docker push -tag> matters for our CD down the line
+          # The order for `docker push -tag` matters for our CD down the line
           tags: |
             ${{ needs.myvars.outputs.TAG_DKR_VERSION }}
             ${{ needs.myvars.outputs.TAG_DKR_BRANCH_NAME }}

--- a/v5/Dockerfile
+++ b/v5/Dockerfile
@@ -4,7 +4,7 @@
 # 1a) ENV variables (core for all our projects at FirePress)
 # ----------------------------------------------
 ARG APP_NAME="ghostfire"
-ARG VERSION="5.112.0"
+ARG VERSION="5.113.0"
 
 ARG GITHUB_USER="firepress-org"
 ARG DEFAULT_BRANCH="master"


### PR DESCRIPTION
Update the Ghost v5 workflow to use a registry-based build cache instead of GHA cache. This improves cache reliability and performance for Docker builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved Docker image build performance by updating the caching mechanism used in the build and deployment process.
  - Updated the application version to 5.113.0 for improved stability and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->